### PR TITLE
Migrate to Bevy 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = { git = "https://github.com/bevyengine/bevy", branch = "main" }
-bevy_asset = { git = "https://github.com/bevyengine/bevy", branch = "main" }
-bevy_render = { git = "https://github.com/bevyengine/bevy", branch = "main" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy", branch = "main" }
+bevy_app = "0.5"
+bevy_asset = "0.5"
+bevy_render = "0.5"
+bevy_utils = "0.5"
 anyhow = "1.0"
 thiserror = "1.0"
 stl_io = "0.5.2"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+bevy = { version = "0.5", default-features = false, features = [
     "render",
     "bevy_wgpu",
     "bevy_winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ thiserror = "1.0"
 stl_io = "0.5.2"
 
 [dev-dependencies]
-#bevy = { git = "https://github.com/bevyengine/bevy", branch = "main" }
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
     "render",
     "bevy_wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,23 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = "0.4"
-bevy_asset = "0.4"
-bevy_render = "0.4"
-bevy_utils = "0.4"
+bevy_app = { git = "https://github.com/bevyengine/bevy", branch = "main" }
+bevy_asset = { git = "https://github.com/bevyengine/bevy", branch = "main" }
+bevy_render = { git = "https://github.com/bevyengine/bevy", branch = "main" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy", branch = "main" }
 anyhow = "1.0"
 thiserror = "1.0"
 stl_io = "0.5.2"
 
 [dev-dependencies]
-bevy = "0.4"
+#bevy = { git = "https://github.com/bevyengine/bevy", branch = "main" }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+    "render",
+    "bevy_wgpu",
+    "bevy_winit",
+    "bevy_gltf",
+    "x11",
+] }
 
 [features]
 default = []

--- a/examples/spinning_disc.rs
+++ b/examples/spinning_disc.rs
@@ -1,13 +1,14 @@
 use bevy::prelude::*;
 use bevy_stl::StlPlugin;
+use bevy_utils::Duration;
 use core::f32::consts::PI;
 
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_plugin(StlPlugin)
-        .add_resource(SpinTimer(Timer::from_seconds(1.0 / 60.0, true)))
+        .insert_resource(SpinTimer(Timer::from_seconds(1.0 / 60.0, true)))
         .add_startup_system(setup.system())
         .add_system(spin_disc.system())
         .run();
@@ -19,30 +20,42 @@ struct Disc {
 
 struct SpinTimer(Timer);
 
-fn setup(commands: &mut Commands, asset_server: Res<AssetServer>, mut materials: ResMut<Assets<StandardMaterial>>) {
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
     commands
-        .spawn(PbrBundle {
+        .spawn_bundle(PbrBundle {
             mesh: asset_server.load("models/disc.stl"),
             material: materials.add(Color::rgb(0.9, 0.4, 0.3).into()),
             transform: Transform::from_rotation(Quat::from_rotation_z(0.0)),
             ..Default::default()
         })
-        .with(Disc { angle: 0.0 })
-        .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, 100.0, 100.0)),
-            ..Default::default()
-        })
-        .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, -100.0, 100.0))
-                .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::unit_y()),
-            ..Default::default()
-        });
+        .insert(Disc { angle: 0.0 });
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_translation(Vec3::new(0.0, 100.0, 100.0)),
+        ..Default::default()
+    });
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_translation(Vec3::new(0.0, -100.0, 100.0))
+            .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+        ..Default::default()
+    });
 }
 
-fn spin_disc(time: Res<Time>, mut timer: ResMut<SpinTimer>, mut query: Query<(&mut Disc, &mut Transform)>) {
-    if timer.0.tick(time.delta_seconds()).just_finished() {
+fn spin_disc(
+    time: Res<Time>,
+    mut timer: ResMut<SpinTimer>,
+    mut query: Query<(&mut Disc, &mut Transform)>,
+) {
+    if timer
+        .0
+        .tick(Duration::from_secs_f32(time.delta_seconds()))
+        .just_finished()
+    {
         for (mut disc, mut transform) in query.iter_mut() {
-            disc.angle = disc.angle + 0.3 * PI/180.0;
+            disc.angle = disc.angle + 0.3 * PI / 180.0;
             *transform = Transform::from_rotation(Quat::from_rotation_z(disc.angle));
         }
     }

--- a/examples/spinning_disc.rs
+++ b/examples/spinning_disc.rs
@@ -34,7 +34,11 @@ fn setup(
         })
         .insert(Disc { angle: 0.0 });
     commands.spawn_bundle(LightBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 100.0, 100.0)),
+        transform: Transform::from_xyz(30.0, 0.0, 20.0),
+        light: Light {
+            range: 40.0,
+            ..Default::default()
+        },
         ..Default::default()
     });
     commands.spawn_bundle(PerspectiveCameraBundle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
 use anyhow::Result;
-use thiserror::Error;
 use std::io::Cursor;
+use thiserror::Error;
 
-use bevy_asset::{AssetLoader, LoadContext, LoadedAsset, AddAsset};
+use bevy_app::prelude::*;
+use bevy_asset::{AddAsset, AssetLoader, LoadContext, LoadedAsset};
 use bevy_render::{
+    mesh::{Indices, Mesh, VertexAttributeValues},
     pipeline::PrimitiveTopology,
-    mesh::{Mesh, VertexAttributeValues, Indices},
 };
 use bevy_utils::BoxedFuture;
-use bevy_app::prelude::*;
 
 pub struct StlPlugin;
 
@@ -25,7 +25,7 @@ impl AssetLoader for StlLoader {
     fn load<'a>(
         &'a self,
         bytes: &'a [u8],
-        load_context: &'a mut LoadContext
+        load_context: &'a mut LoadContext,
     ) -> BoxedFuture<'a, Result<(), anyhow::Error>> {
         Box::pin(async move { Ok(load_stl(bytes, load_context).await?) })
     }
@@ -42,7 +42,10 @@ enum StlError {
     Io(#[from] std::io::Error),
 }
 
-async fn load_stl<'a, 'b>(bytes: &'a [u8], load_context: &'a mut LoadContext<'b>) -> Result<(), StlError> {
+async fn load_stl<'a, 'b>(
+    bytes: &'a [u8],
+    load_context: &'a mut LoadContext<'b>,
+) -> Result<(), StlError> {
     let mut reader = Cursor::new(bytes);
     let stl = stl_io::read_stl(&mut reader)?;
 
@@ -74,8 +77,14 @@ fn stl_to_triangle_mesh(stl: &stl_io::IndexedMesh) -> Mesh {
 
     let uvs = vec![[0.0, 0.0, 0.0]; vertex_count];
 
-    mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, VertexAttributeValues::Float3(positions));
-    mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, VertexAttributeValues::Float3(normals));
+    mesh.set_attribute(
+        Mesh::ATTRIBUTE_POSITION,
+        VertexAttributeValues::Float3(positions),
+    );
+    mesh.set_attribute(
+        Mesh::ATTRIBUTE_NORMAL,
+        VertexAttributeValues::Float3(normals),
+    );
     mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, VertexAttributeValues::Float3(uvs));
     mesh.set_indices(Some(Indices::U32(indices)));
 
@@ -98,8 +107,14 @@ fn stl_to_wireframe_mesh(stl: &stl_io::IndexedMesh) -> Mesh {
         }
     }
 
-    mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, VertexAttributeValues::Float3(positions));
-    mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, VertexAttributeValues::Float3(normals));
+    mesh.set_attribute(
+        Mesh::ATTRIBUTE_POSITION,
+        VertexAttributeValues::Float3(positions),
+    );
+    mesh.set_attribute(
+        Mesh::ATTRIBUTE_NORMAL,
+        VertexAttributeValues::Float3(normals),
+    );
     mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, VertexAttributeValues::Float3(uvs));
     mesh.set_indices(Some(Indices::U32(indices)));
 


### PR DESCRIPTION
Upgrades the plugin to be compatible with Bevy 0.5. Confirmed the example works.

![image](https://user-images.githubusercontent.com/2632925/112762910-1770fd00-8fb7-11eb-81d3-729a34852ac0.png)
