### PR TITLE
Migrate to Bevy 0.12 and upgrade stl_io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,21 +12,23 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { version = "0.12", default-features = false, features = [
     "bevy_asset",
-    "bevy_render"
+    "bevy_render",
 ] }
 anyhow = "1.0"
 thiserror = "1.0"
-stl_io = "0.6.0"
+stl_io = "0.7.0"
+futures-lite = "2.0.1"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { version = "0.12", default-features = false, features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_pbr",
     "bevy_winit",
-    "x11"
+    "tonemapping_luts",
+    "x11",
 ] }
 
 [features]


### PR DESCRIPTION
Hi There! Thanks a lot for this lib! :heart: 

This PR migrates to Bevy 0.12 and upgrades stl_io.

Let me know if you need any changes on this.
