### PR TITLE
Migrate to Bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { version = "0.13.0", default-features = false, features = [
     "bevy_asset",
     "bevy_render",
 ] }
@@ -22,7 +22,7 @@ stl_io = "0.7.0"
 futures-lite = "2.0.1"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { version = "0.13.0", default-features = false, features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_pbr",

--- a/examples/spinning_disc.rs
+++ b/examples/spinning_disc.rs
@@ -29,7 +29,7 @@ fn setup(
     commands.spawn((
         PbrBundle {
             mesh: asset_server.load("models/disc.stl"),
-            material: materials.add(Color::rgb(0.9, 0.4, 0.3).into()),
+            material: materials.add(Color::rgb(0.9, 0.4, 0.3)),
             transform: Transform::from_rotation(Quat::from_rotation_z(0.0)),
             ..Default::default()
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use bevy::{
     render::{
         mesh::{Indices, Mesh, VertexAttributeValues},
         render_resource::PrimitiveTopology,
+        render_asset::RenderAssetUsages,
     },
     utils::BoxedFuture,
 };
@@ -32,7 +33,7 @@ impl AssetLoader for StlLoader {
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a (),
-        _load_context: &'a mut LoadContext,
+        load_context: &'a mut LoadContext,
     ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
@@ -62,7 +63,7 @@ enum StlError {
 }
 
 fn stl_to_triangle_mesh(stl: &stl_io::IndexedMesh) -> Mesh {
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default());
 
     let vertex_count = stl.faces.len() * 3;
 
@@ -90,14 +91,14 @@ fn stl_to_triangle_mesh(stl: &stl_io::IndexedMesh) -> Mesh {
         VertexAttributeValues::Float32x3(normals),
     );
     mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, VertexAttributeValues::Float32x2(uvs));
-    mesh.set_indices(Some(Indices::U32(indices)));
+    mesh.insert_indices(Indices::U32(indices));
 
     mesh
 }
 
 #[cfg(feature = "wireframe")]
 fn stl_to_wireframe_mesh(stl: &stl_io::IndexedMesh) -> Mesh {
-    let mut mesh = Mesh::new(PrimitiveTopology::LineList);
+    let mut mesh = Mesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default());
 
     let positions = stl.vertices.iter().map(|v| [v[0], v[1], v[2]]).collect();
     let mut indices = Vec::with_capacity(stl.faces.len() * 3);
@@ -120,7 +121,7 @@ fn stl_to_wireframe_mesh(stl: &stl_io::IndexedMesh) -> Mesh {
         VertexAttributeValues::Float32x3(normals),
     );
     mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, VertexAttributeValues::Float32x2(uvs));
-    mesh.set_indices(Some(Indices::U32(indices)));
+    mesh.insert_indices(Indices::U32(indices));
 
     mesh
 }


### PR DESCRIPTION
Migrating to Bevy 0.13

Only minimal changes were necessary :tada: 