### PR TITLE
Migrate to bevy 0.14

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Format check
+      run: cargo fmt --verbose --check
     - name: Build
       run: cargo build --verbose
     - name: Build example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,8 @@ bevy = { version = "0.14", default-features = false, features = [
     "bevy_asset",
     "bevy_render",
 ] }
-anyhow = "1.0"
 thiserror = "1.0"
 stl_io = "0.7.0"
-futures-lite = "2.0.1"
 
 [dev-dependencies]
 bevy = { version = "0.14", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
     "bevy_asset",
     "bevy_render",
 ] }
@@ -22,7 +22,7 @@ stl_io = "0.7.0"
 futures-lite = "2.0.1"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_pbr",

--- a/examples/spinning_disc.rs
+++ b/examples/spinning_disc.rs
@@ -29,7 +29,7 @@ fn setup(
     commands.spawn((
         PbrBundle {
             mesh: asset_server.load("models/disc.stl"),
-            material: materials.add(Color::rgb(0.9, 0.4, 0.3)),
+            material: materials.add(Color::srgb(0.9, 0.4, 0.3)),
             transform: Transform::from_rotation(Quat::from_rotation_z(0.0)),
             ..Default::default()
         },

--- a/examples/spinning_disc.rs
+++ b/examples/spinning_disc.rs
@@ -7,7 +7,10 @@ fn main() {
         .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
         .add_plugins(StlPlugin)
-        .insert_resource(SpinTimer(Timer::from_seconds(1.0 / 60.0, TimerMode::Repeating)))
+        .insert_resource(SpinTimer(Timer::from_seconds(
+            1.0 / 60.0,
+            TimerMode::Repeating,
+        )))
         .add_systems(Startup, setup)
         .add_systems(Update, spin_disc)
         .run();
@@ -33,7 +36,7 @@ fn setup(
             transform: Transform::from_rotation(Quat::from_rotation_z(0.0)),
             ..Default::default()
         },
-        Disc { angle: 0.0 }
+        Disc { angle: 0.0 },
     ));
     commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(30.0, 0.0, 20.0),

--- a/examples/spinning_disc_wireframe.rs
+++ b/examples/spinning_disc_wireframe.rs
@@ -32,7 +32,7 @@ fn setup(
     commands.spawn((
         PbrBundle {
             mesh: asset_server.load("models/disc.stl#wireframe"),
-            material: materials.add(Color::rgb(0.9, 0.4, 0.3)),
+            material: materials.add(Color::srgb(0.9, 0.4, 0.3)),
             transform: Transform::from_rotation(Quat::from_rotation_z(0.0)),
             ..Default::default()
         },

--- a/examples/spinning_disc_wireframe.rs
+++ b/examples/spinning_disc_wireframe.rs
@@ -7,7 +7,10 @@ fn main() {
         .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
         .add_plugins(StlPlugin)
-        .insert_resource(SpinTimer(Timer::from_seconds(1.0 / 60.0, TimerMode::Repeating)))
+        .insert_resource(SpinTimer(Timer::from_seconds(
+            1.0 / 60.0,
+            TimerMode::Repeating,
+        )))
         .add_systems(Startup, setup)
         .add_systems(Update, spin_disc)
         .run();
@@ -33,7 +36,7 @@ fn setup(
             transform: Transform::from_rotation(Quat::from_rotation_z(0.0)),
             ..Default::default()
         },
-        Disc { angle: 0.0 }
+        Disc { angle: 0.0 },
     ));
     commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(30.0, 0.0, 20.0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ use bevy::{
     prelude::*,
     render::{
         mesh::{Indices, Mesh, VertexAttributeValues},
-        render_resource::PrimitiveTopology,
         render_asset::RenderAssetUsages,
+        render_resource::PrimitiveTopology,
     },
 };
 
@@ -59,7 +59,10 @@ enum StlError {
 }
 
 fn stl_to_triangle_mesh(stl: &stl_io::IndexedMesh) -> Mesh {
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default());
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    );
 
     let vertex_count = stl.faces.len() * 3;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use std::io::Cursor;
 use thiserror::Error;
 


### PR DESCRIPTION
This PR migrates the crate to 0.14.

I split it in two:

* https://github.com/nilclass/bevy_stl/commit/15b94d88dda2297ad0573d7dd89c5d4215d8bc80 does the minimum needed to get the crate to compile without warnings in 0.14
* https://github.com/nilclass/bevy_stl/commit/f07cdb1c24aa62f91d12860175f724cc51ef3929 Runs `cargo fmt` on the codebase to clean it up a bit.

Happy to remove the second if needed, I thought it would be nice to get the crate in a clean `cargo fmt` state