### PR TITLE
Migration to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_stl"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Niklas Cathor <niklas.cathor@gmx.de>"]
 edition = "2021"
 license = "MIT"
@@ -12,25 +12,26 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_asset",
     "bevy_render",
 ] }
-thiserror = "1.0"
-stl_io = "0.7.0"
+thiserror = "2.0"
+stl_io = "0.8.3"
 
 [dev-dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_pbr",
     "bevy_winit",
+    "bevy_window",
     "tonemapping_luts",
     "x11",
 ] }
 
 [features]
-default = []
+default = ["wireframe"]
 
 # Along with the triangle mesh, generate an additional wireframe mesh (a PrimitiveTopology::LineList).
 # The wireframe mesh can be accessed by `asset_server.load("my-model.stl#wireframe")`.

--- a/README.md
+++ b/README.md
@@ -32,14 +32,11 @@ fn main() {
         .run();
 }
 
-fn setup(commands: &mut Commands, asset_server: Res<AssetServer>, mut materials: ResMut<Assets<StandardMaterial>>) {
-    commands
-        .spawn(PbrBundle {
-            mesh: asset_server.load("disc.stl"),
-            material: materials.add(Color::rgb(0.9, 0.4, 0.3).into()),
-            ..Default::default()
-        })
-        // ...
+fn setup(commands: Commands, asset_server: Res<AssetServer>, mut materials: ResMut<Assets<StandardMaterial>>) {
+    commands.spawn((
+        Mesh3d(asset_server.load("disc.stl")),
+        MeshMaterial3d(Color::rgb(0.9, 0.4, 0.3).into()),
+    ));
 }
 ```
 

--- a/examples/spinning_disc.rs
+++ b/examples/spinning_disc.rs
@@ -4,7 +4,6 @@ use core::f32::consts::PI;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
         .add_plugins(StlPlugin)
         .insert_resource(SpinTimer(Timer::from_seconds(
@@ -30,27 +29,24 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     commands.spawn((
-        PbrBundle {
-            mesh: asset_server.load("models/disc.stl"),
-            material: materials.add(Color::srgb(0.9, 0.4, 0.3)),
-            transform: Transform::from_rotation(Quat::from_rotation_z(0.0)),
-            ..Default::default()
-        },
+        Mesh3d(asset_server.load("models/disc.stl")),
+        MeshMaterial3d(materials.add(Color::srgb(0.9, 0.4, 0.3))),
+        Transform::from_rotation(Quat::from_rotation_z(0.0)),
         Disc { angle: 0.0 },
     ));
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(30.0, 0.0, 20.0),
-        point_light: PointLight {
+    commands.spawn((
+        Transform::from_xyz(30.0, 0.0, 20.0),
+        PointLight {
             range: 40.0,
             ..Default::default()
         },
-        ..Default::default()
-    });
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, -100.0, 100.0))
+    ));
+    commands.spawn((
+        Transform::from_translation(Vec3::new(0.0, -100.0, 100.0))
             .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+        Camera3d::default(),
+        Msaa::Sample4,
+    ));
 }
 
 fn spin_disc(
@@ -60,7 +56,7 @@ fn spin_disc(
 ) {
     if timer
         .0
-        .tick(Duration::from_secs_f32(time.delta_seconds()))
+        .tick(Duration::from_secs_f32(time.delta_secs()))
         .just_finished()
     {
         for (mut disc, mut transform) in query.iter_mut() {

--- a/examples/spinning_disc_wireframe.rs
+++ b/examples/spinning_disc_wireframe.rs
@@ -4,7 +4,6 @@ use core::f32::consts::PI;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
         .add_plugins(StlPlugin)
         .insert_resource(SpinTimer(Timer::from_seconds(
@@ -30,27 +29,24 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     commands.spawn((
-        PbrBundle {
-            mesh: asset_server.load("models/disc.stl#wireframe"),
-            material: materials.add(Color::srgb(0.9, 0.4, 0.3)),
-            transform: Transform::from_rotation(Quat::from_rotation_z(0.0)),
-            ..Default::default()
-        },
+        Mesh3d(asset_server.load("models/disc.stl#wireframe")),
+        MeshMaterial3d(materials.add(Color::srgb(0.9, 0.4, 0.3))),
+        Transform::from_rotation(Quat::from_rotation_z(0.0)),
         Disc { angle: 0.0 },
     ));
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(30.0, 0.0, 20.0),
-        point_light: PointLight {
+    commands.spawn((
+        Transform::from_xyz(30.0, 0.0, 20.0),
+        PointLight {
             range: 40.0,
             ..Default::default()
         },
-        ..Default::default()
-    });
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, -100.0, 100.0))
+    ));
+    commands.spawn((
+        Transform::from_translation(Vec3::new(0.0, -100.0, 100.0))
             .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+        Msaa::Sample4,
+    )
+    );
 }
 
 fn spin_disc(
@@ -60,7 +56,7 @@ fn spin_disc(
 ) {
     if timer
         .0
-        .tick(Duration::from_secs_f32(time.delta_seconds()))
+        .tick(Duration::from_secs_f32(time.delta_secs()))
         .just_finished()
     {
         for (mut disc, mut transform) in query.iter_mut() {

--- a/examples/spinning_disc_wireframe.rs
+++ b/examples/spinning_disc_wireframe.rs
@@ -44,6 +44,7 @@ fn setup(
     commands.spawn((
         Transform::from_translation(Vec3::new(0.0, -100.0, 100.0))
             .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+        Camera3d::default(),
         Msaa::Sample4,
     )
     );

--- a/examples/spinning_disc_wireframe.rs
+++ b/examples/spinning_disc_wireframe.rs
@@ -46,8 +46,7 @@ fn setup(
             .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
         Camera3d::default(),
         Msaa::Sample4,
-    )
-    );
+    ));
 }
 
 fn spin_disc(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,10 @@ impl AssetLoader for StlLoader {
     type Settings = ();
     type Error = StlError;
     async fn load(
-        & self,
-        reader: & mut dyn Reader,
-        _settings: & (),
-        #[allow(unused_variables)]
-        load_context: & mut LoadContext<'_>,
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        #[allow(unused_variables)] load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 use thiserror::Error;
 
 use bevy::{
-    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
+    asset::{io::Reader, AssetLoader, LoadContext},
     prelude::*,
     render::{
         mesh::{Indices, Mesh, VertexAttributeValues},
@@ -26,11 +26,12 @@ impl AssetLoader for StlLoader {
     type Asset = Mesh;
     type Settings = ();
     type Error = StlError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a (),
-        #[allow(unused)] load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        & self,
+        reader: & mut dyn Reader,
+        _settings: & (),
+        #[allow(unused_variables)]
+        load_context: & mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -102,7 +103,6 @@ fn stl_to_wireframe_mesh(stl: &stl_io::IndexedMesh) -> Mesh {
     let mut indices = Vec::with_capacity(stl.faces.len() * 3);
     let normals = vec![[1.0, 0.0, 0.0]; stl.vertices.len()];
     let uvs = vec![[0.0, 0.0]; stl.vertices.len()];
-
     for face in &stl.faces {
         for j in 0..3 {
             indices.push(face.vertices[j] as u32);


### PR DESCRIPTION
Here is the code for the migration to 0.15.
May I ask why Msaa::Sample4 is specified? I think it should default to 4 anyway (keep in mind that in this last version it changed place).
And in addition to that why the example run with the constant spin timer? It is not cleaner to set it to the elapsed time? or move from one frame to the other with delta_secs*constant?

Nice work btw