### PR TITLE
add uppercase file extension

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl AssetLoader for StlLoader {
     }
 
     fn extensions(&self) -> &[&str] {
-        static EXTENSIONS: &[&str] = &["stl"];
+        static EXTENSIONS: &[&str] = &["stl", "STL"];
         EXTENSIONS
     }
 }


### PR DESCRIPTION
Bevy 0.16 had became case-sensitive for asset file extensions https://github.com/bevyengine/bevy/pull/17065
So add uppercase `STL` extension to keep the original behavior of bevy_stl plugin